### PR TITLE
Reuse pool and wallet handles, separate selfserve logs from indy, cle…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]

--- a/selfserve/main_selfserve/main.py
+++ b/selfserve/main_selfserve/main.py
@@ -5,6 +5,13 @@ from routes import setup_static_routes
 
 app = web.Application()
 app['pool_lock'] = asyncio.Lock()
+app['handles'] = {
+    'pools': {
+        'stagingnet': None,
+        'buildernet': None
+    },
+    'wallet': None
+}
 setup_routes(app)
 setup_static_routes(app)
-web.run_app(app, host='localhost', port=8080)
+web.run_app(app, host='127.0.0.1', port=8080)

--- a/selfserve/main_selfserve/main.py
+++ b/selfserve/main_selfserve/main.py
@@ -1,10 +1,12 @@
 import asyncio
+import logging
 from aiohttp import web
 from routes import setup_routes
 from routes import setup_static_routes
 
+from indy import wallet, pool
+
 app = web.Application()
-app['pool_lock'] = asyncio.Lock()
 app['handles'] = {
     'pools': {
         'stagingnet': None,
@@ -12,6 +14,37 @@ app['handles'] = {
     },
     'wallet': None
 }
+WALLET = "stewardauto" #"test"
+WALLETKEY = "stewardauto" #"test"
+LOG_LEVEL = logging.INFO
+LOGGER = logging.getLogger('Startup')
+
+## - Functions - ##
+async def open_handles():
+    await pool.set_protocol_version(2)
+    LOGGER.info("Opening steward_wallet")
+    app['handles']['wallet'] = await wallet.open_wallet(f'{{"id": "{WALLET}"}}', f'{{"key": "{WALLETKEY}"}}')
+    for pool_name in app['handles']['pools']:
+        LOGGER.info(f"Connecting to pool: {pool_name}")
+        app['handles']['pools'][pool_name] = await pool.open_pool_ledger(pool_name, None)
+
+async def close_handles():
+    LOGGER.info("Closing steward_wallet")
+    await wallet.close_wallet(app['handles']['wallet'])
+    for pool_name in app['handles']['pools']:
+        LOGGER.info(f"Closing pool: {pool_name}")
+        await pool.close_pool_ledger(app['handles']['pools'][pool_name])
+
+## - Main - ##
+logging.basicConfig(level=LOG_LEVEL)
+
+LOOP = asyncio.get_event_loop()
+LOOP.run_until_complete(open_handles())
+
 setup_routes(app)
 setup_static_routes(app)
 web.run_app(app, host='127.0.0.1', port=8080)
+
+LOOP = asyncio.new_event_loop()
+LOOP.run_until_complete(close_handles())
+LOOP.close()

--- a/selfserve/main_selfserve/nym.py
+++ b/selfserve/main_selfserve/nym.py
@@ -24,8 +24,6 @@ from indy.error import ErrorCode, IndyError
 
 #BuilderNetPool = "testpool" #"buildernet"
 #StagingNetPool = "testpool" #"stagingnet"
-Wallet = "stewardauto" #"test"
-WalletKey = "stewardauto" #"test"
 StewardDID = "V5qJo72nMeF7x3ci8Zv2WP" #"Th7MpTaRZVRYnPiabds81Y"
 BuilderPaymentAddress="pay:sov:52CuALbWKBX66sDnmf8zL5HvxFYyjzFNuaibERRNhPgKP1bBu"
 StagingPaymentAddress="pay:sov:2k8PCrjjMZUpQo6XGef1duDpeFQrhHf3A2BnWKmMBh5nuegNuD"
@@ -36,11 +34,7 @@ PAYMENT_METHOD = 'sov'
 PAYMENT_PREFIX = 'pay:sov:'
 DEFAULT_TOKENS_AMOUNT=200000000000
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('selfserv')
-
-indy_logger = logging.getLogger('indy') #(__name__)
-indy_logger.setLevel(logging.DEBUG)
 
 # Uncomment the following to write logs to STDOUT
 #
@@ -77,15 +71,9 @@ async def addNYMs(network, handles, NYMs):
     # Open pool ledger
     utctimestamp = int(datetime.datetime.utcnow().timestamp())
     pool_name = network
-    await pool.set_protocol_version(2)
 
-    if handles['pools'][network] == None:
-        logger.info("First time open pool ledger %s.", pool_name)
-        handles['pools'][network] = await pool.open_pool_ledger(pool_name, None)
-        pool_handle = handles['pools'][network]
-    else:
-        logger.info("Reusing open pool ledger handle for %s.", pool_name)
-        pool_handle = handles['pools'][network]
+    logger.info("Using open pool ledger handle for %s.", pool_name)
+    pool_handle = handles['pools'][network]
 #    wait5seconds=5
 #    while NOT pool_handle AND wait5seconds-- > 0:
 #        sleep(1)
@@ -93,16 +81,8 @@ async def addNYMs(network, handles, NYMs):
     logger.debug("After open pool ledger %s.", pool_name)
 
     # Open Wallet and Get Wallet Handle
-    if handles['wallet'] == None:
-        logger.info("First time opening steward_wallet")
-        wallet_name = Wallet
-        wallet_config = json.dumps({"id": wallet_name})
-        wallet_credentials = json.dumps({"key": WalletKey})
-        handles['wallet'] = await wallet.open_wallet(wallet_config, wallet_credentials)
-        steward_wallet_handle = handles['wallet']
-    else:
-        logger.info("Reusing already opened steward wallet handle")
-        steward_wallet_handle = handles['wallet']
+    logger.info("Using steward wallet handle")
+    steward_wallet_handle = handles['wallet']
 
     # Use Steward DID
     #logger.debug("Before use steward did")
@@ -378,27 +358,12 @@ async def xferTokens(network, handles, NYMs):
     # Open pool ledger
     utctimestamp = int(datetime.datetime.utcnow().timestamp())
     pool_name = network
-    await pool.set_protocol_version(2)
-
-    if handles['pools'][network] == None:
-        logger.info("First time open pool ledger %s.", pool_name)
-        handles['pools'][network] = await pool.open_pool_ledger(pool_name, None)
-        pool_handle = handles['pools'][network]
-    else:
-        logger.info("Reusing open pool ledger handle for %s.", pool_name)
-        pool_handle = handles['pools'][network]
+    logger.info("Using open pool ledger handle for %s.", pool_name)
+    pool_handle = handles['pools'][network]
 
     # Open Wallet and Get Wallet Handle
-    if handles['wallet'] == None:
-        logger.info("First time opening steward_wallet")
-        wallet_name = Wallet
-        wallet_config = json.dumps({"id": wallet_name})
-        wallet_credentials = json.dumps({"key": WalletKey})
-        handles['wallet'] = await wallet.open_wallet(wallet_config, wallet_credentials)
-        steward_wallet_handle = handles['wallet']
-    else:
-        logger.info("Reusing already opened steward wallet handle")
-        steward_wallet_handle = handles['wallet']
+    logger.info("Using steward wallet handle")
+    steward_wallet_handle = handles['wallet']
 
     isotimestamp = datetime.datetime.now().isoformat()
 
@@ -814,7 +779,6 @@ def my_handler(event, context):
     return response
 
 async def handle_nym_req(request):
-    pool_lock = request.app['pool_lock']
     handles = request.app['handles']
     responseCode = 200
     responseBody={}
@@ -859,8 +823,7 @@ async def handle_nym_req(request):
 
         if nyms[0]['DID'] and nyms[0]['verkey']:
             logger.debug("Call addNYMs...")
-            async with pool_lock:
-                responseBody_nym = await addNYMs(poolName, handles, nyms)
+            responseBody_nym = await addNYMs(poolName, handles, nyms)
             logger.debug("Adding nym is complete...")
         if nyms[0]['paymentaddr']:
             logger.debug("Call xferTokens...")

--- a/selfserve/main_selfserve/nym.py
+++ b/selfserve/main_selfserve/nym.py
@@ -36,8 +36,11 @@ PAYMENT_METHOD = 'sov'
 PAYMENT_PREFIX = 'pay:sov:'
 DEFAULT_TOKENS_AMOUNT=200000000000
 
-logger = logging.getLogger('indy') #(__name__)
-logger.setLevel(logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger('selfserv')
+
+indy_logger = logging.getLogger('indy') #(__name__)
+indy_logger.setLevel(logging.DEBUG)
 
 # Uncomment the following to write logs to STDOUT
 #
@@ -64,7 +67,7 @@ async def writeEndorserRegistrationLog(entry, status, reason, isotimestamp):
                     }
                 )
 
-async def addNYMs(network, NYMs):
+async def addNYMs(network, handles, NYMs):
     # A dict to hold the results keyed on DID
     result = {
         "statusCode": 200
@@ -76,20 +79,30 @@ async def addNYMs(network, NYMs):
     pool_name = network
     await pool.set_protocol_version(2)
 
-    logger.debug("Before open pool ledger %s.", pool_name)
-    pool_handle = await pool.open_pool_ledger(pool_name, None)
+    if handles['pools'][network] == None:
+        logger.info("First time open pool ledger %s.", pool_name)
+        handles['pools'][network] = await pool.open_pool_ledger(pool_name, None)
+        pool_handle = handles['pools'][network]
+    else:
+        logger.info("Reusing open pool ledger handle for %s.", pool_name)
+        pool_handle = handles['pools'][network]
 #    wait5seconds=5
 #    while NOT pool_handle AND wait5seconds-- > 0:
 #        sleep(1)
 #        pool_handle = await pool.open_pool_ledger(pool_name, None)
     logger.debug("After open pool ledger %s.", pool_name)
- 
+
     # Open Wallet and Get Wallet Handle
-    logger.debug("Before open steward_wallet")
-    wallet_name = Wallet
-    wallet_config = json.dumps({"id": wallet_name})
-    wallet_credentials = json.dumps({"key": WalletKey})
-    steward_wallet_handle = await wallet.open_wallet(wallet_config, wallet_credentials)
+    if handles['wallet'] == None:
+        logger.info("First time opening steward_wallet")
+        wallet_name = Wallet
+        wallet_config = json.dumps({"id": wallet_name})
+        wallet_credentials = json.dumps({"key": WalletKey})
+        handles['wallet'] = await wallet.open_wallet(wallet_config, wallet_credentials)
+        steward_wallet_handle = handles['wallet']
+    else:
+        logger.info("Reusing already opened steward wallet handle")
+        steward_wallet_handle = handles['wallet']
 
     # Use Steward DID
     #logger.debug("Before use steward did")
@@ -115,7 +128,7 @@ async def addNYMs(network, NYMs):
             #logger.debug("Before write Endorser registration log")
             #await writeEndorserRegistrationLog(entry, status, reason, isotimestamp)
             #logger.debug("After write Endorser registration log")
-  
+
         # Does the DID we are assigning Endorser role exist on the ledger?
             logger.debug("Before build_get_nym_request")
             get_nym_txn_req = await ledger.build_get_nym_request(steward_did, entry["DID"])
@@ -125,7 +138,7 @@ async def addNYMs(network, NYMs):
             logger.debug("After submit_request")
             logger.debug("submit_request JSON response >%s<", get_nym_txn_resp)
             get_nym_txn_resp = json.loads(get_nym_txn_resp)
-  
+
             # Create identity owner if it does not yet exist
             if (get_nym_txn_resp['result']['data'] == None):
                 reason = "DID does not exist. Creating Endorser identity."
@@ -149,14 +162,14 @@ async def addNYMs(network, NYMs):
                     nym_txn_req = await ledger.append_txn_author_agreement_acceptance_to_request(nym_txn_req, add_taa_resp["result"]["data"]["text"], add_taa_resp["result"]["data"]["version"], None, 'service_agreement', utctimestamp)
                 logger.debug("After append TAA to build_nym request")
                 logger.debug("After build_nym_request")
-   
+
                 logger.debug("Before sign_and_submit_request")
                 await ledger.sign_and_submit_request(pool_handle, steward_wallet_handle, steward_did, nym_txn_req)
                 logger.debug("After sign_and_submit_request")
                 logger.debug("Before sleep .3 seconds")
                 await asyncio.sleep(.3)
                 logger.debug("After sleep .3 seconds")
-   
+
                 reason = "Endorser identity written to the ledger. Confirming DID exists on the ledger."
                 # Log that a check for did on STN is in progress. Logging this
                 # status/reason may be useful in determining where interation with the STN
@@ -222,14 +235,6 @@ async def addNYMs(network, NYMs):
         if statusCode > result['statusCode']:
             logger.debug("Status code >%d< is greater than result.statusCode >%d<", statusCode, result['statusCode'])
             result['statusCode'] = statusCode
-
-    # Close wallets and pool
-    logger.debug("Before close_wallet")
-    await wallet.close_wallet(steward_wallet_handle)
-    logger.debug("After close_wallet")
-    logger.debug("Before close_pool_ledger")
-    await pool.close_pool_ledger(pool_handle)
-    logger.debug("After close_pool_ledger")
 
     return result 
 #    logger.debug("Before set future result")
@@ -336,7 +341,7 @@ async def transferTokens(pool_handle, wallet_handle, steward_did, source_payment
     payment_req, payment_method = await payment.build_payment_req(wallet_handle, steward_did,
                                                                 json.dumps(inputs), json.dumps(outputs), extras)
     logging.debug("Gothere8")
-   
+
     logger.debug("Payment request >%s<", payment_req)
     logger.debug("After build_payment_req")
 
@@ -359,7 +364,7 @@ async def transferTokens(pool_handle, wallet_handle, steward_did, source_payment
         err.status_code = 500
         raise err
 
-async def xferTokens(network, NYMs):
+async def xferTokens(network, handles, NYMs):
 # A dict to hold the results keyed on DID
     logger.debug("Begin xferTokens Function")
     result = {
@@ -374,17 +379,26 @@ async def xferTokens(network, NYMs):
     utctimestamp = int(datetime.datetime.utcnow().timestamp())
     pool_name = network
     await pool.set_protocol_version(2)
- 
-    logger.debug("Before open pool ledger %s.", pool_name)
-    pool_handle = await pool.open_pool_ledger(pool_name, None)
-    logger.debug("After open pool ledger %s.", pool_name)
+
+    if handles['pools'][network] == None:
+        logger.info("First time open pool ledger %s.", pool_name)
+        handles['pools'][network] = await pool.open_pool_ledger(pool_name, None)
+        pool_handle = handles['pools'][network]
+    else:
+        logger.info("Reusing open pool ledger handle for %s.", pool_name)
+        pool_handle = handles['pools'][network]
 
     # Open Wallet and Get Wallet Handle
-    logger.debug("Before open steward_wallet")
-    wallet_name = Wallet
-    wallet_config = json.dumps({"id": wallet_name})
-    wallet_credentials = json.dumps({"key": WalletKey})
-    steward_wallet_handle = await wallet.open_wallet(wallet_config, wallet_credentials)
+    if handles['wallet'] == None:
+        logger.info("First time opening steward_wallet")
+        wallet_name = Wallet
+        wallet_config = json.dumps({"id": wallet_name})
+        wallet_credentials = json.dumps({"key": WalletKey})
+        handles['wallet'] = await wallet.open_wallet(wallet_config, wallet_credentials)
+        steward_wallet_handle = handles['wallet']
+    else:
+        logger.info("Reusing already opened steward wallet handle")
+        steward_wallet_handle = handles['wallet']
 
     isotimestamp = datetime.datetime.now().isoformat()
 
@@ -426,7 +440,7 @@ async def xferTokens(network, NYMs):
                 source_payment_address=StagingPaymentAddress
             else:   # Testing
                 source_payment_address=TrainingPaymentAddress 
-            
+
             # First find out the xfer fee...
             xfer_fee = 0
             logger.debug("Before build_get_txn_fees_req.")
@@ -494,14 +508,6 @@ async def xferTokens(network, NYMs):
         logger.error(err)
 
     await writeEndorserRegistrationLog(entry, status, reason, isotimestamp)
-
-    # Close wallets and pool
-    logger.debug("Before close_wallet")
-    await wallet.close_wallet(steward_wallet_handle)
-    logger.debug("After close_wallet")
-    logger.debug("Before close_pool_ledger")
-    await pool.close_pool_ledger(pool_handle)
-    logger.debug("After close_pool_ledger")
 
     # Add status and reason for the status for each DID to the result
     result[entry["DID"]] = {
@@ -809,6 +815,7 @@ def my_handler(event, context):
 
 async def handle_nym_req(request):
     pool_lock = request.app['pool_lock']
+    handles = request.app['handles']
     responseCode = 200
     responseBody={}
     responseBody_nym={}
@@ -853,7 +860,7 @@ async def handle_nym_req(request):
         if nyms[0]['DID'] and nyms[0]['verkey']:
             logger.debug("Call addNYMs...")
             async with pool_lock:
-                responseBody_nym = await addNYMs(poolName, nyms)
+                responseBody_nym = await addNYMs(poolName, handles, nyms)
             logger.debug("Adding nym is complete...")
         if nyms[0]['paymentaddr']:
             logger.debug("Call xferTokens...")
@@ -923,16 +930,16 @@ def main():
     parser.add_argument('--payment-address', action="store", dest="paymentaddr",
         help="The Endorser's email address.")
     args = parser.parse_args()
-  
+
     # TODO: Add the logic to either add a single record or many from a CSV file.
     nyms = []
-  
+
     # Validate and build nyms from request body; setting name and sourceIP for
     # each nym.
     # TODO: Currently a non-empty 'name' is required. Set the default to None
     #       once ledger.build_nym_request accepts None for the NYM 'name/alias'
     errors = {}
-  
+
     # Mock a body from the client
     body = {
         "did": args.DID,
@@ -940,7 +947,7 @@ def main():
         "name": args.name,
         "paymentaddr": args.paymentaddr
     }
-  
+
     # Mock an event from the AWS API Gateway
     event = {
         "requestContext": {
@@ -955,10 +962,10 @@ def main():
         nyms.append(endorserNym(body, event))
     else:
         errors = addErrors(args.DID, errors, tmp_errors)
-  
+
     if bool(errors) == False:
         poolName = args.genesisFile.split("_")[-2]
-  
+
         loop = asyncio.get_event_loop()
         # Pass the 'future' handle to addNYMs to allow addNYMs to set the future's
         # 'result'.
@@ -967,15 +974,15 @@ def main():
           args.stewardSeed, nyms))
         loop.run_until_complete(future)
         loop.close()
-  
+
         responseBody = future.result()
     else:
         # Return validation errors
         errors['statusCode'] = 400
         responseBody = errors
-  
+
     responseCode = responseBody['statusCode']
-  
+
     # The output from a Lambda proxy integration must be
     # of the following JSON object. The 'headers' property
     # is for custom response headers in addition to standard
@@ -991,7 +998,7 @@ def main():
     }
     logging.debug("response: %s" % json.dumps(response))
     logging.debug("%s" % json.dumps(response))
-  
+
     if responseCode != 200:
        sys.exit(1)
     else:

--- a/selfserve_load.py
+++ b/selfserve_load.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+import base58
+import random
+
+def rand_str(length):
+    res = ''
+    lower = 'abcdefghijklmnopqrstuvwxyz'
+    upper = lower.upper()
+    num = '01234567890'
+    charset = lower + upper + num
+    for i in range(0, length): #pylint: disable=unused-variable
+        res += random.choice(charset)
+    return res
+
+for i in range(50):
+    shell_snippet="""(
+    DID='{DID}'
+    VKEY='~{VKEY}'
+    resp=$(curl -sSd "{{\\"network\\":\\"stagingnet\\",\\"did\\":\\"{DID}\\",\\"verkey\\":\\"~{VKEY}\\",\\"paymentaddr\\":\\"\\"}}" http://127.0.0.1:8080/nym 2>&1)
+    if [ $? -ne 0 ] ; then
+        echo "Request for DID: {DID} and VerKey: ~{VKEY} FAILED!!"
+        echo "$resp"
+    else
+        if echo "$resp" | grep -q '"statusCode": 200' ; then
+            echo "Request for DID: {DID} and VerKey: ~{VKEY} was successful"
+        else
+            echo "Request for DID: {DID} and VerKey: ~{VKEY} FAILED!!"
+            echo "$resp"
+        fi
+    fi
+) &""".format(DID=base58.b58encode(rand_str(16)).decode(), VKEY=base58.b58encode(rand_str(16)).decode())
+    print(shell_snippet)
+print('echo')
+print('wait')


### PR DESCRIPTION
* Reuse pool and wallet handles
* Separate selfserve logs from indy
* Cleanup whitespace
* Add .gitignore
* Initialize the wallet and pool handles as part of startup to prevent
    possible race condition where a pool handle could be created and lost if
    a client cancels their http request at just the "right" time
* Remove the asyncio lock/semaphore for better request concurrency
* Adjust logging so that a single var in `main.py` can be used adjust
    the log level across all modules.
* Set the default log level to INFO