### PR TITLE
Fix xfer parallelization

### DIFF
--- a/selfserve/main_selfserve/main.py
+++ b/selfserve/main_selfserve/main.py
@@ -14,6 +14,7 @@ app['handles'] = {
     },
     'wallet': None
 }
+app['xfer_lock'] = asyncio.Lock()
 WALLET = "stewardauto" #"test"
 WALLETKEY = "stewardauto" #"test"
 LOG_LEVEL = logging.INFO


### PR DESCRIPTION
Apparently token transfers have to be done sequentially otherwise libindy will raise errors.

This will protect _just_ the xferTokens function so that other `nym` requests can still be done async, but any parallel token transfers will by sync.