### PR TITLE
raw_input() was removed from Python on 1/1/2020

### DIFF
--- a/github-contributor-scripts/github-contributors-list-enhanced.py
+++ b/github-contributor-scripts/github-contributors-list-enhanced.py
@@ -12,7 +12,7 @@ total_contributions = 0
 weekly_contributions = dict()
 
 if len(sys.argv) < 2:
-   token=raw_input("GitHub Authentication Token: ")
+   token=input("GitHub Authentication Token: ")
 else:
    token=sys.argv[1]
    


### PR DESCRIPTION
Signed-off-by: Christian Clauss <cclauss@me.com>